### PR TITLE
fix: SPI transactions on esp32

### DIFF
--- a/src/vl53l8cx.h
+++ b/src/vl53l8cx.h
@@ -179,6 +179,7 @@ class VL53L8CX {
             *(p_values + i + position) = dev_spi->transfer(0x00);
           }
           digitalWrite(cs_pin, HIGH);
+          dev_spi->endTransaction();
         }
         return 0;
       }
@@ -248,6 +249,7 @@ class VL53L8CX {
           digitalWrite(cs_pin, LOW);
           dev_spi->transfer(&data_write, data_size);
           digitalWrite(cs_pin, HIGH);
+          dev_spi->endTransaction();
         }
         return status;
       }


### PR DESCRIPTION
**Summary**
This is an issue I was facing using this sensor on ESP32 and was recently raised by another person also: (#19)

On platforms where `beginTransaction()` acquires a mutex (e.g. ESP32), failing to call `endTransaction()` causes the second SPI call to deadlock.

`IO_Read` and `IO_Write` both called `beginTransaction()` but never released the bus, causing the MCU to freeze during init() firmware upload.

STM32 is unaffected as `beginTransaction()` is a no-op (ie. this is a non-breaking aka backwards compatible change).

This PR fixes/implements the following:

* [x] Bug / Feature - Add tested support for esp32 by ensuring `endTransaction()` is called when using SPI

**Motivation**
This library works perfectly on esp32 once this issue is fixed, without it, it hangs on the second transaction due to the mutex.

**Validation**
Tested with [demo sketch](examples/VL53L8CX_HelloWorld_SPI/VL53L8CX_HelloWorld_SPI.ino)  in both PlatformIO v6.1.19 and Arduino IDE v2.3.8.

**Closing issues**
Closes #19 
