### PR TITLE
Support using efficient interrupts over polling for data (with updated examples)

### DIFF
--- a/examples/VL53L8CX_HelloWorld_I2C/VL53L8CX_HelloWorld_I2C.ino
+++ b/examples/VL53L8CX_HelloWorld_I2C/VL53L8CX_HelloWorld_I2C.ino
@@ -50,7 +50,7 @@
  * pin 9 (3V3) of the VL53L8CX satellite not connected
  * pin 10 (1V8) of the VL53L8CX satellite not connected
  * pin 11 (5V) of the VL53L8CX satellite connected to 5V of the Nucleo board
- * GPIO1 of VL53L8CX satellite connected to A2 pin of the Nucleo board (not used)
+ * GPIO1 of VL53L8CX satellite connected to A2 pin of the Nucleo board (used in INT pin mode)
  * GND of the VL53L8CX satellite connected to GND of the Nucleo board
  */
 
@@ -68,6 +68,10 @@
 
 #define LPN_PIN A3
 #define PWREN_PIN 11
+#define INT_PIN A2
+
+// Uncomment to use INT pin mode instead of polling over I2C
+// #define USE_INT_PIN
 
 void print_result(VL53L8CX_ResultsData *Result);
 void clear_screen(void);
@@ -75,7 +79,11 @@ void handle_cmd(uint8_t cmd);
 void display_commands_banner(void);
 
 // Components.
-VL53L8CX sensor_vl53l8cx_top(&DEV_I2C, LPN_PIN);
+#ifdef USE_INT_PIN
+  VL53L8CX sensor_vl53l8cx_top(&DEV_I2C, LPN_PIN, -1, INT_PIN);
+#else
+  VL53L8CX sensor_vl53l8cx_top(&DEV_I2C, LPN_PIN);
+#endif
 
 bool EnableAmbient = false;
 bool EnableSignal = false;

--- a/examples/VL53L8CX_HelloWorld_SPI/VL53L8CX_HelloWorld_SPI.ino
+++ b/examples/VL53L8CX_HelloWorld_SPI/VL53L8CX_HelloWorld_SPI.ino
@@ -50,7 +50,7 @@
  * pin 9 (3V3) of the VL53L8CX satellite not connected
  * pin 10 (1V8) of the VL53L8CX satellite not connected
  * pin 11 (5V) of the VL53L8CX satellite connected to 5V of the Nucleo board
- * GPIO1 of VL53L8CX satellite connected to A2 pin of the Nucleo board (not used)
+ * GPIO1 of VL53L8CX satellite connected to A2 pin of the Nucleo board (used in INT pin mode)
  * GND of the VL53L8CX satellite connected to GND of the Nucleo board
  */
 
@@ -67,6 +67,10 @@
 #define SPI_MISO_PIN  5
 #define SPI_MOSI_PIN 4
 #define CS_PIN 10
+#define INT_PIN A2
+
+// Uncomment to use INT pin mode instead of polling over SPI
+// #define USE_INT_PIN
 
 SPIClass DEV_SPI(SPI_MOSI_PIN, SPI_MISO_PIN, SPI_CLK_PIN);
 
@@ -75,7 +79,11 @@ void clear_screen(void);
 void handle_cmd(uint8_t cmd);
 void display_commands_banner(void);
 
-VL53L8CX sensor_vl53l8cx_top(&DEV_SPI, CS_PIN);
+#ifdef USE_INT_PIN
+  VL53L8CX sensor_vl53l8cx_top(&DEV_SPI, CS_PIN, -1, -1, INT_PIN);
+#else
+  VL53L8CX sensor_vl53l8cx_top(&DEV_SPI, CS_PIN);
+#endif
 
 bool EnableAmbient = false;
 bool EnableSignal = false;

--- a/src/vl53l8cx.cpp
+++ b/src/vl53l8cx.cpp
@@ -44,8 +44,12 @@
   * @param i2c device I2C to be used for communication
   * @param _lpn_pin pin to be used as component LPn
   * @param _i2c_rst_pin pin to be used as component I2C_RST
+  * @param _int_pin pin connected to the sensor INT/GPIO1 line (active LOW, data-ready signal).
+  *        Pass -1 (default) to disable; check_data_ready() will poll over I2C instead.
+  *        When set, begin() configures the pin as INPUT_PULLUP and check_data_ready()
+  *        reads the pin state directly, avoiding an I2C transaction per call.
   */
-VL53L8CX::VL53L8CX(TwoWire *i2c, int _lpn_pin, int _i2c_rst_pin): dev_i2c(i2c), lpn_pin(_lpn_pin), i2c_rst_pin(_i2c_rst_pin)
+VL53L8CX::VL53L8CX(TwoWire *i2c, int _lpn_pin, int _i2c_rst_pin, int _int_pin): dev_i2c(i2c), lpn_pin(_lpn_pin), i2c_rst_pin(_i2c_rst_pin), int_pin(_int_pin)
 {
   memset((void *)&_dev, 0x0, sizeof(VL53L8CX_Configuration));
   dev_spi = NULL;
@@ -61,9 +65,13 @@ VL53L8CX::VL53L8CX(TwoWire *i2c, int _lpn_pin, int _i2c_rst_pin): dev_i2c(i2c), 
   * @param _cs_pin the chip select pin
   * @param _lpn_pin pin to be used as component LPn
   * @param _i2c_rst_pin pin to be used as component I2C_RST
+  * @param _int_pin pin connected to the sensor INT/GPIO1 line (active LOW, data-ready signal).
+  *        Pass -1 (default) to disable; check_data_ready() will poll over SPI instead.
+  *        When set, begin() configures the pin as INPUT_PULLUP and check_data_ready()
+  *        reads the pin state directly, avoiding a bus transaction per call.
   * @param _spi_speed the SPI speed in Hz
   */
-VL53L8CX::VL53L8CX(SPIClass *spi, int _cs_pin, int _lpn_pin, int _i2c_rst_pin, uint32_t _spi_speed)  : dev_spi(spi), cs_pin(_cs_pin), lpn_pin(_lpn_pin), i2c_rst_pin(_i2c_rst_pin),  spi_speed(_spi_speed)
+VL53L8CX::VL53L8CX(SPIClass *spi, int _cs_pin, int _lpn_pin, int _i2c_rst_pin, int _int_pin, uint32_t _spi_speed)  : dev_spi(spi), cs_pin(_cs_pin), lpn_pin(_lpn_pin), i2c_rst_pin(_i2c_rst_pin), int_pin(_int_pin), spi_speed(_spi_speed)
 {
   memset((void *)&_dev, 0x0, sizeof(VL53L8CX_Configuration));
   dev_i2c = NULL;
@@ -104,6 +112,9 @@ int VL53L8CX::begin()
     // Configure CS pin
     pinMode(cs_pin, OUTPUT);
     digitalWrite(cs_pin, HIGH);
+  }
+  if (int_pin >= 0) {
+    pinMode(int_pin, INPUT_PULLUP);
   }
   return 0;
 }
@@ -242,6 +253,10 @@ uint8_t VL53L8CX::stop_ranging(void)
   */
 uint8_t VL53L8CX::check_data_ready(uint8_t *p_isReady)
 {
+  if (int_pin >= 0) {
+    *p_isReady = (digitalRead(int_pin) == LOW) ? 1 : 0;
+    return VL53L8CX_STATUS_OK;
+  }
   return vl53l8cx_check_data_ready(p_dev, p_isReady);
 }
 

--- a/src/vl53l8cx.h
+++ b/src/vl53l8cx.h
@@ -52,8 +52,8 @@
 /* Class Declaration ---------------------------------------------------------*/
 class VL53L8CX {
   public:
-    VL53L8CX(TwoWire *i2c, int lpn_pin, int i2c_rst_pin = -1);
-    VL53L8CX(SPIClass *spi, int cs_pin, int lpn_pin = -1, int i2c_rst_pin = -1, uint32_t spi_speed = 5000000);
+    VL53L8CX(TwoWire *i2c, int lpn_pin, int i2c_rst_pin = -1, int int_pin = -1);
+    VL53L8CX(SPIClass *spi, int cs_pin, int lpn_pin = -1, int i2c_rst_pin = -1, int int_pin = -1, uint32_t spi_speed = 5000000);
     virtual ~VL53L8CX(void);
     virtual int begin(void);
     virtual int end(void);
@@ -275,8 +275,9 @@ class VL53L8CX {
 
     /* Configuration */
     int cs_pin;
-    int  lpn_pin;
+    int lpn_pin;
     int i2c_rst_pin;
+    int int_pin;
     uint32_t spi_speed;
 
     VL53L8CX_Configuration _dev;


### PR DESCRIPTION
**Summary**
Add support for using interrupts for data ready checking vs polling (~10 - 30x more efficient).

BREAKING CHANGE: SPI constructor (insert of INT_PIN parameter before `spi_speed` parameter).
This was done for parameter consistency between SPI + I2C constructors.

It is only a breaking change if `spi_speed` was already manually specified - recommend a major version bump if following [semver standards](https://semver.org/).

I2C constructor is not a breaking change (INT_PIN added as optional last parameter)
Both default INT_PIN to -1 (which will be ignored)


**Motivation**
Increase efficiency in the use of this driver when wiring and specifying INT pin.

**Validation**
Tested with [demo sketch](https://github.com/rpocklin/VL53L8CX/blob/add-interrupt-feature/examples/VL53L8CX_HelloWorld_SPI/VL53L8CX_HelloWorld_SPI.ino) on PlatformIO v6.1.19.
